### PR TITLE
Change google credentials path to absolute and latest file in bucket

### DIFF
--- a/workflow_orchestration/airflow/dags/dag_sp500.py
+++ b/workflow_orchestration/airflow/dags/dag_sp500.py
@@ -44,7 +44,7 @@ def yfinance_to_gcs(bucket_name):
         sp500_df.to_csv(local_file_path)
         
         # Upload to latest folder
-        latest_object_name = f'latest/sp500_finance_data_{date}.csv.gz'
+        latest_object_name = f'latest/sp500_finance_data.csv.gz'
         upload_to_gcs(bucket_name, latest_object_name, local_file_path)
         
         # Upload to historical folder

--- a/workflow_orchestration/airflow/docker-compose.yaml
+++ b/workflow_orchestration/airflow/docker-compose.yaml
@@ -79,7 +79,7 @@ x-airflow-common:
     - ./dags:/opt/airflow/dags
     - ./logs:/opt/airflow/logs
     - ./plugins:/opt/airflow/plugins
-    - ~/.google/credentials/:/.google/credentials:ro
+    - /home/stavros/.google/credentials/:/.google/credentials:ro
 
   user: "${AIRFLOW_UID:-50000}:0"
   depends_on:


### PR DESCRIPTION
In this PR:
1. Changing the path to /google_credentials in `docker-compose.yml` to be absolute instead of relative. This is because there was an error in the dag_sp500 with "file not found".
2. Changing the file named that is used when uploading to the latest/ folder in the bucket to excluded the date, as it is supposed to overwrite.